### PR TITLE
Add missing test in TestJSLibHTTPDownload

### DIFF
--- a/js_lib_test.go
+++ b/js_lib_test.go
@@ -237,6 +237,7 @@ func TestJSLibHTTPDownload(t *testing.T) {
 	require.FileExists(t, "foo.txt")
 	require.FileExists(t, "dir/my-foo.txt")
 	require.FileExists(t, "dir/bar.txt")
+	require.FileExists(t, "dir/baz.txt")
 	require.FileExists(t, "qux.txt")
 	require.FileExists(t, "hack.txt")
 	require.FileExists(t, "no-dest.txt")


### PR DESCRIPTION
It looks like the baz file was created but not test. In this PR, I added require for this file.

```BASH
$ go test -test.v -run TestJSLibHTTPDownload ./...
```