### PR TITLE
Removed "Error"

### DIFF
--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -26,7 +26,7 @@ func (c *DevCommand) Run(args []string) error {
 
 	cfg, err := parseConfigArgs(fs.Args()[1:])
 	if err != nil {
-		return fmt.Errorf("Error parsing config flags: %w", err)
+		return fmt.Errorf("parsing config flags: %w", err)
 	}
 
 	return flyscrape.Dev(fs.Arg(0), cfg)

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -26,7 +26,7 @@ func (c *DevCommand) Run(args []string) error {
 
 	cfg, err := parseConfigArgs(fs.Args()[1:])
 	if err != nil {
-		return fmt.Errorf("parsing config flags: %w", err)
+		return fmt.Errorf("error parsing config flags: %w", err)
 	}
 
 	return flyscrape.Dev(fs.Arg(0), cfg)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -26,7 +26,7 @@ func (c *RunCommand) Run(args []string) error {
 
 	cfg, err := parseConfigArgs(fs.Args()[1:])
 	if err != nil {
-		return fmt.Errorf("Error parsing config flags: %w", err)
+		return fmt.Errorf("parsing config flags: %w", err)
 	}
 
 	return flyscrape.Run(fs.Arg(0), cfg)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -26,7 +26,7 @@ func (c *RunCommand) Run(args []string) error {
 
 	cfg, err := parseConfigArgs(fs.Args()[1:])
 	if err != nil {
-		return fmt.Errorf("parsing config flags: %w", err)
+		return fmt.Errorf("error parsing config flags: %w", err)
 	}
 
 	return flyscrape.Run(fs.Arg(0), cfg)


### PR DESCRIPTION
The "return" already implies an error.

Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context.